### PR TITLE
Prevent NaN in the time field in the emitted  XML 

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ var JUnitReporter = function(baseReporterDecorator, config, emitter, logger, hel
     suite.att('tests', result.total);
     suite.att('errors', result.disconnected || result.error ? 1 : 0);
     suite.att('failures', result.failed);
-    suite.att('time', result.netTime / 1000);
+    suite.att('time', (result.netTime || 0) / 1000);
 
     suite.ele('system-out').dat(allMessages.join() + '\n');
     suite.ele('system-err');
@@ -72,7 +72,7 @@ var JUnitReporter = function(baseReporterDecorator, config, emitter, logger, hel
 
   this.specSuccess = this.specSkipped = this.specFailure = function(browser, result) {
     var spec = suites[browser.id].ele('testcase', {
-      name: result.description, time: result.time / 1000,
+      name: result.description, time: ((result.time || 0) / 1000),
       classname: (pkgName ? pkgName + ' ' : '') + browser.name + '.' + result.suite.join(' ').replace(/\./g, '_')
     });
 


### PR DESCRIPTION
...d (or perhaps some other cases).  NaN in an int field causes most XML parsers to fail.

In this cases, Sonar would not process the results.

This will address a portion of issue #1 I'm sure.
