### PR TITLE
Removing browser from each individual test report.

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ var JUnitReporter = function(baseReporterDecorator, config, logger, helper, form
   this.specSuccess = this.specSkipped = this.specFailure = function(browser, result) {
     var spec = suites[browser.id].ele('testcase', {
       name: result.description, time: ((result.time || 0) / 1000),
-      classname: (pkgName ? pkgName + ' ' : '') + browser.name + '.' + result.suite.join(' ').replace(/\./g, '_')
+      classname: (pkgName ? pkgName + ' ' : '') + result.suite.join(' ').replace(/\./g, '_')
     });
 
     if (result.skipped) {


### PR DESCRIPTION
I would like to ask you to consider this:

As the browser information is included in the test suite name, I do not believe that this is needed in each `testcase` node.

For our use-case at the BBC this extra meta data creates problems for us when transforming the data.