### PR TITLE
fix: prevent fatal error when browser failed to start

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ var JUnitReporter = function(baseReporterDecorator, config, logger, helper, form
   };
 
   this.onBrowserComplete = function(browser) {
-    var suite = suites[browser.id];
+    var suite = suites && suites[browser.id];
 
     if (!suite) {
       // This browser did not signal `onBrowserStart`. That happens
@@ -65,6 +65,10 @@ var JUnitReporter = function(baseReporterDecorator, config, logger, helper, form
 
   this.onRunComplete = function() {
     var xmlToOutput = xml;
+
+    if (!xml) {
+      return fileWritingFinished();
+    }
 
     pendingFileWritings++;
     helper.mkdirIfNotExists(path.dirname(outputFile), function() {


### PR DESCRIPTION
fixes #20

This is just a workaround, I guess `onBrowserComplete`  normally should never be called multiple times for same browser. Grunt won't fail at least if it happens so.