### PR TITLE
fix: index.js - eval suite if it is json string.

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,6 +86,10 @@ var JUnitReporter = function(baseReporterDecorator, config, logger, helper, form
   };
 
   this.specSuccess = this.specSkipped = this.specFailure = function(browser, result) {
+    // prototype.js causes the suite array to be turned into a string, eval it back into an array.
+    if (result.suite.indexOf('[') == 0) {
+      result.suite = eval(result.suite);
+    }
     var spec = suites[browser.id].ele('testcase', {
       name: result.description, time: ((result.time || 0) / 1000),
       classname: (pkgName ? pkgName + ' ' : '') + browser.name + '.' + result.suite.join(' ').replace(/\./g, '_')


### PR DESCRIPTION
If prototype.js is specified in the karma config, the specSucess fails.
This is because the result.suite is a json string instead of the
array which it evalutes into.  This patch resolves the issue by
eval'ing the json back into an array.  I suppose it would be a problem
if the name of the suite began with "[", however.  Not sure how
likely that is?

Closes #30
