### PR TITLE
Fix: Modified how classname is generated to be usable in sonar

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,72 @@ You can pass list of reporters as a CLI argument too:
 karma start --reporters junit,dots
 ```
 
+## Produce test result with schema acceptable in sonar
+
+To make this possible, it's required to make the classnames of each tests to match its file name.
+
+For Example:
+```js
+describe('analytics.AnalyticsModule_test', function(){
+
+    var analytics;
+    beforeEach(module('ECApp'));
+    beforeEach(module('angularytics'));
+    beforeEach(module('AnalyticsModule'));
+...
+```
+
+should have a file name AnalyticsModule_test.js
+
+This will produce test result with schema acceptable in sonar.
+
+Grunt file reporters property example:
+```js
+reporters: ['junit', 'coverage', 'progress'],
+junitReporter: {
+    outputDir: $junitResults,
+    suite: 'models'
+},
+coverageReporter: {
+    type: 'lcov',
+    dir: $coverageOutputDir,
+    subdir: '.'
+},
+preprocessors: {
+    'src/main/webapp/public/js/ec3.3/**/*.js': 'coverage',
+    'src/main/webapp/public/js/ec3/**/*.js': 'coverage'
+},
+plugins: [
+    'karma-jasmine',
+    'karma-phantomjs-launcher',
+    'ec-karma-junit-reporter23',
+    'karma-coverage'
+]
+```
+
+Sonar property example:
+```js
+sonar.projectName=js
+sonar.sources=site-main-php/src/main/webapp/public/js
+sonar.projectBaseDir=.
+sonar.exclusions=site-main-php/src/main/webapp/public/js/lib/*.js,site-main-php/src/main/webapp/public/js/tests/**/*.php,site-main-php/src/main/webapp/public/js/tests/**/*.js,site-main-php/src/main/webapp/public/js/ec3.3/vendor/**
+sonar.javascript.lcov.reportPath=site-main-php/target/coverage/lcov.info
+sonar.javascript.jstestdriver.reportsPath=site-main-php/target/surefire-reports/
+sonar.tests=site-main-php/src/main/webapp/public/js/tests
+```
+
+Example junit xml report:
+```xml
+<?xml version="1.0"?>
+<testsuite name="PhantomJS 1.9.8 (Linux)" package="models" timestamp="2015-03-10T13:59:23" id="0" hostname="admin" tests="629" errors="0" failures="0" time="11.452">
+  <properties>
+    <property name="browser.fullName" value="Mozilla/5.0 (Unknown; Linux x86_64) AppleWebKit/534.34 (KHTML, like Gecko) PhantomJS/1.9.8 Safari/534.34"/>
+  </properties>
+ <testcase name="(C.2) Checks if an empty object is returned when error 404 is encountered" time="0.01" classname="PhantomJS_1_9_8_(Linux).models.AnalyticsModule_test"/>
+ <testcase name="(C.3) Checks if an empty array is returned when error 405 is encountered" time="0.013" classname="PhantomJS_1_9_8_(Linux).models.AnalyticsModule_test"/>
+</testsuite>
+...
+```
 ----
 
 For more information on Karma see the [homepage].


### PR DESCRIPTION
These changes will allow assigning of relative path to classnames. Relative path of the test file will be constructed using sonar.tests property and junitReporter "suite" property.  I also applied the xml schema change to use this 
format (from https://github.com/karma-runner/karma-junit-reporter/pull/26):
```
< testcase >
< error / >
< /testcase >
< testcase >
< failure />
< /testcase >  
```
In the case below, test files are located in site-main-php/src/main/webapp/public/js/tests/models directory.

Sonar property example:
```
sonar.projectName=js
sonar.sources=site-main-php/src/main/webapp/public/js
sonar.projectBaseDir=.
sonar.exclusions=site-main-php/src/main/webapp/public/js/lib/*.js,site-main-php/src/main/webapp/public/js/tests/**/*.php,site-main-php/src/main/webapp/public/js/tests/**/*.js,site-main-php/src/main/webapp/public/js/ec3.3/vendor/**
sonar.javascript.lcov.reportPath=site-main-php/target/coverage/lcov.info
sonar.javascript.jstestdriver.reportsPath=site-main-php/target/surefire-reports/
sonar.tests=site-main-php/src/main/webapp/public/js/tests
```
Grunt file reporters property example:
```
reporters: ['junit', 'coverage', 'progress'],
junitReporter: {
    outputDir: $junitResults,
    suite: 'models'
},
coverageReporter: {
    type: 'lcov',
    dir: $coverageOutputDir,
    subdir: '.'
},
preprocessors: {
    'src/main/webapp/public/js/ec3.3/**/*.js': 'coverage',
    'src/main/webapp/public/js/ec3/**/*.js': 'coverage'
},
plugins: [
    'karma-jasmine',
    'karma-phantomjs-launcher',
    'ec-karma-junit-reporter23',
    'karma-coverage'
]
```
Example junit xml report:
```
<?xml version="1.0"?>
<testsuite name="PhantomJS 1.9.8 (Linux)" package="models" timestamp="2015-03-10T13:59:23" id="0" hostname="admin" tests="629" errors="0" failures="0" time="11.452">
  <properties>
    <property name="browser.fullName" value="Mozilla/5.0 (Unknown; Linux x86_64) AppleWebKit/534.34 (KHTML, like Gecko) PhantomJS/1.9.8 Safari/534.34"/>
  </properties>
 <testcase name="(C.2) Checks if an empty object is returned when error 404 is encountered" time="0.01" classname="PhantomJS_1_9_8_(Linux).models.ReportCardDialogService_test"/>
 <testcase name="(C.3) Checks if an empty array is returned when error 405 is encountered" time="0.013" classname="PhantomJS_1_9_8_(Linux).models.ReportCardDialogService_test"/>
</testsuite>
```