### PR TITLE
Handle browser script failure and put the error into browser report

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,23 +72,30 @@ var JUnitReporter = function (baseReporterDecorator, config, logger, helper, for
 
     if (!suite) {
       // This browser did not signal `onBrowserStart`. That happens
-      // if the browser timed out during the start phase.
-      return
+      // if the browser timed out during the start phase or javascript
+      // exception has occured.
+      initliazeXmlForBrowser(browser)
+      if (browser.lastResult.error) {
+        suite = suites[browser.id]
+        suite.ele('error').dat(allMessages.join() + '\n')
+        allMessages = []
+      }
+    } else {
+      var result = browser.lastResult
+
+      suite.att('tests', result.total)
+      suite.att('errors', result.disconnected || result.error ? 1 : 0)
+      suite.att('failures', result.failed)
+      suite.att('time', (result.netTime || 0) / 1000)
+
+      if (result.disconnected) {
+        suite.ele('error').att('message', 'Browser disconnected')
+      }
+
+      suite.ele('system-out').dat(allMessages.join() + '\n')
+      allMessages = []
+      suite.ele('system-err')
     }
-
-    var result = browser.lastResult
-
-    suite.att('tests', result.total)
-    suite.att('errors', result.disconnected || result.error ? 1 : 0)
-    suite.att('failures', result.failed)
-    suite.att('time', (result.netTime || 0) / 1000)
-
-    if (result.disconnected) {
-      suite.ele('error').att('message', 'Browser disconnected')
-    }
-
-    suite.ele('system-out').dat(allMessages.join() + '\n')
-    suite.ele('system-err')
 
     writeXmlForBrowser(browser)
   }


### PR DESCRIPTION
The latest version and master handle browser errors improperly. If an exception happens in a browser, report for this browser will be missing and error information will get into some other (random, which run after the failed one) browsers report as system-out property. 

This fix handles such cases. Collected `allMessages` array is treated as error body and written to the `error` tag for the failed browsers. `allMessages` array is cleared afterwards to not put the same information into other browsers reports. This also makes CI system (teamcity for example) to parse out the error and show it in the build log.