### PR TITLE
Use files in package.json

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,0 @@
-.*
-junit-schema.xsd
-Gruntfile.coffee
-CONTRIBUTING.md

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.3.1",
   "description": "A Karma plugin. Report results in junit xml format.",
   "main": "index.js",
+  "files": [
+    "index.js"
+  ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Whitelist instead of blacklist. In this case, you went from gruntfile in coffeescript to js without updating `.npmignore`, so it was included when installing. With this change, that wouldn't happen.

Before:
```
-rw-r--r--  0 501    20       1464 Jul 19 15:58 package/package.json
-rw-r--r--  0 501    20       1835 Jul 19 15:58 package/README.md
-rw-r--r--  0 501    20       1077 Jul 19 15:58 package/LICENSE
-rw-r--r--  0 501    20        831 Jul 19 15:58 package/gruntfile.js
-rw-r--r--  0 501    20       4107 Jul 19 15:58 package/index.js
-rw-r--r--  0 501    20       1472 Jul 19 15:58 package/CHANGELOG.md
```

After:
```
-rw-r--r--  0 501    20       1497 Jul 19 16:01 package/package.json
-rw-r--r--  0 501    20       1835 Jul 19 15:58 package/README.md
-rw-r--r--  0 501    20       1077 Jul 19 15:58 package/LICENSE
-rw-r--r--  0 501    20       4107 Jul 19 15:58 package/index.js
-rw-r--r--  0 501    20       1472 Jul 19 15:58 package/CHANGELOG.md
```