### PR TITLE
fix: update regex for browser name to repace backslash '/' with '_'

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ var JUnitReporter = function (baseReporterDecorator, config, logger, helper, for
   }
 
   var writeXmlForBrowser = function (browser) {
-    var outputFile = outputDir + 'TESTS-' + browser.name.replace(/ /g, '_') + '.xml'
+    var outputFile = outputDir + 'TESTS-' + browser.name.replace(/ |\//g, '_') + '.xml'
     var xmlToOutput = suites[browser.id]
     if (!xmlToOutput) {
       return // don't die if browser didn't start


### PR DESCRIPTION
In my setup with SlimerJS, karma-junit-fails to create the xml files because the browser.name contains back-slashes '/' with 'Mozilla/5.0 (X11; Linux x86_64; rv:38.0) Gecko/20100101 SlimerJS/0.9.6' . This results in an error similar to the following:

```
17 09 2015 23:55:39.016:WARN [reporter.junit]: Cannot write JUnit xml
    ENOENT: no such file or directory, open '/target/xunit/unit-tests/Mozilla/5.0_(X11__Linux_x86_64__rv_38.0)_Gecko/20100101_SlimerJS_0.9.6/TESTS-SlimerJS.xml'
```

Replacing the backslash with '_' fixes this issue.
