### PR TITLE
Add useBrowserName parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ module.exports = function(config) {
     junitReporter: {
       outputDir: '', // results will be saved as $outputDir/$browserName.xml
       outputFile: undefined, // if included, results will be saved as $outputDir/$browserName/$outputFile
-      suite: '' // suite will become the package name attribute in xml testsuite element
+      suite: '', // suite will become the package name attribute in xml testsuite element
+      useBrowserName: true // add browser name to report and classes names
     }
   });
 };


### PR DESCRIPTION
I had a problem with karma-junit-reporter - weird browser name in report file name and in class name. I don't need more than one browser and decided to add `useBrowserName`