### PR TITLE
feat: add name and classname formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ module.exports = function(config) {
       outputFile: undefined, // if included, results will be saved as $outputDir/$browserName/$outputFile
       suite: '', // suite will become the package name attribute in xml testsuite element
       useBrowserName: true // add browser name to report and classes names
+      nameFormatter: undefined, // function (browser, result) to customize the name attribute in xml testcase element
+      classNameFormatter: undefined // function (browser, result) to customize the classname attribute in xml testcase element
     }
   });
 };

--- a/index.js
+++ b/index.js
@@ -10,6 +10,8 @@ var JUnitReporter = function (baseReporterDecorator, config, logger, helper, for
   var outputDir = reporterConfig.outputDir
   var outputFile = reporterConfig.outputFile
   var useBrowserName = reporterConfig.useBrowserName
+  var nameFormatter = reporterConfig.nameFormatter
+  var classNameFormatter = reporterConfig.classNameFormatter
 
   var suites
   var pendingFileWritings = 0
@@ -123,8 +125,9 @@ var JUnitReporter = function (baseReporterDecorator, config, logger, helper, for
 
   this.specSuccess = this.specSkipped = this.specFailure = function (browser, result) {
     var spec = suites[browser.id].ele('testcase', {
-      name: result.description, time: ((result.time || 0) / 1000),
-      classname: getClassName(browser, result)
+      name: typeof nameFormatter === 'function' ? nameFormatter(browser, result) : result.description,
+      time: ((result.time || 0) / 1000),
+      classname: (typeof classNameFormatter === 'function' ? classNameFormatter : getClassName)(browser, result)
     })
 
     if (result.skipped) {


### PR DESCRIPTION
As promised, this implements #75 – allow custom name/classname attributes for test cases.