### PR TITLE
Fixing the bug where nested describe namespace was flattened.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,4 @@ For more information on Karma see the [homepage].
 
 
 [homepage]: http://karma-runner.github.com
+

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,0 +1,31 @@
+The unofficial to-do for karma-junit-reporter
+=============================================
+
+Planned milestones :
+
+20.3.2016	Continuous testing ready for karma-junit-reporter
+                 - adding tests to this project
+                 - make them run the standard Travis way: in npm's package.json 'scripts' 
+                   section, add the "test" command                
+
+Also, check whether the PR coming from this fork (branch) fixes these issues: 
+1. https://github.com/karma-runner/karma-junit-reporter/issues/81
+   - needs sanity check of one variable, in a manner that might have to
+     take into account the index is not numerable?
+     - basically it's either 
+        1.    if (x) ...
+        2. or if (x && (typeof x[theIndex] !== undefined)) ... 
+
+Specifics
+=========
+
+- in Travis
+  - add a simple test spec, for my code of kjur, to make Travis fail first
+    - this works as a kind of POC: "I got the test technically running!"
+  - add the real tests case (1) to the chain of tests to be done
+    - now a little bit of think-work would be nice. Does the test go for
+      a) just checking the getClassName() 
+      b) add some intelligence and conform to the ways this reporter is actually used?
+
+- make sure the ./test folder is committed
+- get filestuff right within the ./test 

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ var JUnitReporter = function (baseReporterDecorator, config, logger, helper, for
       allMessages.push(msg)
     }
   ]
- 
+
   var initializeXmlForBrowser = function (browser) {
     var timestamp = (new Date()).toISOString().substr(0, 19)
     var suite = suites[browser.id] = builder.create('testsuite')

--- a/index.js
+++ b/index.js
@@ -82,10 +82,19 @@ var JUnitReporter = function (baseReporterDecorator, config, logger, helper, for
   }
 
   var getClassName = function (browser, result) {
-    var browserName = browser.name.replace(/ /g, '_').replace(/\./g, '_') + '.'
-    var namesNested = '' 
-    if (result.suite && result.suite.length > 0) { namesNested = result.suite.join(' ') }
-    return (useBrowserName ? browserName : '') + (pkgName ? pkgName + '.' : '') + namesNested 
+    var name='' 
+    if (useBrowserName) {
+      name += browser.name
+        .replace (/ /g, '_')
+        .replace (/\./g, '_') + '.'
+    }
+    if (pkgName) {
+      name += '.'
+    }
+    if (result.suite && result.suite.length > 0) {
+      name += result.suite.join(' ')
+    }
+    return name
   }
 
   this.onRunStart = function (browsers) {

--- a/index.js
+++ b/index.js
@@ -83,8 +83,9 @@ var JUnitReporter = function (baseReporterDecorator, config, logger, helper, for
 
   var getClassName = function (browser, result) {
     var browserName = browser.name.replace(/ /g, '_').replace(/\./g, '_') + '.'
-
-    return (useBrowserName ? browserName : '') + (pkgName ? pkgName + '.' : '') + result.suite[0]
+    var namesNested = ''; 
+    if (result.suite && result.suite.length > 0) { namesNested = result.suite.join(' '); }
+    return (useBrowserName ? browserName : '') + (pkgName ? pkgName + '.' : '') + namesNested; 
   }
 
   this.onRunStart = function (browsers) {

--- a/index.js
+++ b/index.js
@@ -33,8 +33,8 @@ var JUnitReporter = function (baseReporterDecorator, config, logger, helper, for
       allMessages.push(msg)
     }
   ]
-
-  var initliazeXmlForBrowser = function (browser) {
+ 
+  var initializeXmlForBrowser = function (browser) {
     var timestamp = (new Date()).toISOString().substr(0, 19)
     var suite = suites[browser.id] = builder.create('testsuite')
     suite.att('name', browser.name)
@@ -101,11 +101,11 @@ var JUnitReporter = function (baseReporterDecorator, config, logger, helper, for
     suites = Object.create(null)
 
     // TODO(vojta): remove once we don't care about Karma 0.10
-    browsers.forEach(initliazeXmlForBrowser)
+    browsers.forEach(initializeXmlForBrowser)
   }
 
   this.onBrowserStart = function (browser) {
-    initliazeXmlForBrowser(browser)
+    initializeXmlForBrowser(browser)
   }
 
   this.onBrowserComplete = function (browser) {

--- a/index.js
+++ b/index.js
@@ -83,9 +83,9 @@ var JUnitReporter = function (baseReporterDecorator, config, logger, helper, for
 
   var getClassName = function (browser, result) {
     var browserName = browser.name.replace(/ /g, '_').replace(/\./g, '_') + '.'
-    var namesNested = ''; 
-    if (result.suite && result.suite.length > 0) { namesNested = result.suite.join(' '); }
-    return (useBrowserName ? browserName : '') + (pkgName ? pkgName + '.' : '') + namesNested; 
+    var namesNested = '' 
+    if (result.suite && result.suite.length > 0) { namesNested = result.suite.join(' ') }
+    return (useBrowserName ? browserName : '') + (pkgName ? pkgName + '.' : '') + namesNested 
   }
 
   this.onRunStart = function (browsers) {

--- a/index.js
+++ b/index.js
@@ -82,11 +82,11 @@ var JUnitReporter = function (baseReporterDecorator, config, logger, helper, for
   }
 
   var getClassName = function (browser, result) {
-    var name='' 
+    var name = ''
     if (useBrowserName) {
       name += browser.name
-        .replace (/ /g, '_')
-        .replace (/\./g, '_') + '.'
+        .replace(/ /g, '_')
+        .replace(/\./g, '_') + '.'
     }
     if (pkgName) {
       name += '.'

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "index.js"
   ],
   "scripts": {
-    "jp-test": "mocha --compilers coffee:coffee-script",
-    "test": "grunt test"
+    "jp-test": "mocha --compilers coffee:coffee-script"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "index.js"
   ],
   "scripts": {
-    "test": "grunt"
+    "jp-test": "mocha --compilers coffee:coffee-script",
+    "test": "grunt test"
   },
   "repository": {
     "type": "git",
@@ -27,6 +28,7 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "chai": "^3.5.0",
     "eslint": "^1.2.1",
     "eslint-config-standard": "^4.1.0",
     "eslint-plugin-standard": "^1.3.1",
@@ -36,7 +38,9 @@
     "grunt-conventional-github-releaser": "^0.4.0",
     "grunt-eslint": "^17.1.0",
     "grunt-npm": "^0.0.2",
-    "load-grunt-tasks": "^3.2.0"
+    "load-grunt-tasks": "^3.2.0",
+    "mocha": "^2.4.5",
+    "should": ">= 0.0.1"
   },
   "contributors": [
     "dignifiedquire <dignifiedquire@gmail.com>",


### PR DESCRIPTION
This code handles both degenerate (zero-length) and normal cases
of array of test suite names.

Somewhere from 0.3.3 onwards there was a bug creeping in. This caused the 
namespace to flatten, ie. only the first word of a namespace was included. This corresponds
to a flat namespace. 

Nested describe's (per Jasmine language) were being flattened thus and overlaps of names
started happening. 