### PR TITLE
Handle Absolute outputFile path

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,9 @@ var JUnitReporter = function (baseReporterDecorator, config, logger, helper, for
   var writeXmlForBrowser = function (browser) {
     var safeBrowserName = browser.name.replace(/ /g, '_')
     var newOutputFile
-    if (outputFile != null) {
+    if (path.isAbsolute(outputFile)) {
+      newOutputFile = outputFile
+    } else if (outputFile != null) {
       var dir = useBrowserName ? path.join(outputDir, safeBrowserName)
                                : outputDir
       newOutputFile = path.join(dir, outputFile)


### PR DESCRIPTION
On my machine (Windows 10, nodejs 4.2.3) the Karma Junit reporter was failing with errors like the following:

``
WARN [reporter.junit]: Cannot write JUnit xml
        ENOENT: no such file or directory, open 'c:\code\myproject\src\myproject.Web\PhantomJS_1.9.8_(Windows_8)\c:\code\myproject\src\myproject.Web\test-results.xml'
``

So, outputFile was coming into the Karma Junit reporter as an absolute path instead of a relative, or even just a file name.

The code changes in this PR fixed the issue for me.