### PR TITLE
docs: Added missing comma to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ module.exports = function(config) {
       suite: '', // suite will become the package name attribute in xml testsuite element
       useBrowserName: true, // add browser name to report and classes names
       nameFormatter: undefined, // function (browser, result) to customize the name attribute in xml testcase element
-      classNameFormatter: undefined // function (browser, result) to customize the classname attribute in xml testcase element,
+      classNameFormatter: undefined, // function (browser, result) to customize the classname attribute in xml testcase element
       properties: {} // key value pair of properties to add to the <properties> section of the report
     }
   });


### PR DESCRIPTION
I've copy pasted the config from the README and it failed -
I was missing a comma. So I am submitting this fix.