### PR TITLE
docs: fixes two missing commas.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ module.exports = function(config) {
       suite: '', // suite will become the package name attribute in xml testsuite element
       useBrowserName: true, // add browser name to report and classes names
       nameFormatter: undefined, // function (browser, result) to customize the name attribute in xml testcase element
-      classNameFormatter: undefined // function (browser, result) to customize the classname attribute in xml testcase element,
+      classNameFormatter: undefined, // function (browser, result) to customize the classname attribute in xml testcase element,
       properties: {} // key value pair of properties to add to the <properties> section of the report
-    }
+    },
   });
 };
 ```


### PR DESCRIPTION
Fixes two missing commas that were causing tests to fail if a user chose to copy and paste the example configuration exactly.