### PR TITLE
Remove unnecessary nulling out of `suites`

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,6 +105,7 @@ var JUnitReporter = function (baseReporterDecorator, config, logger, helper, for
     return (useBrowserName ? browserName : '') + (pkgName ? pkgName + '.' : '') + result.suite[0]
   }
 
+  // "run_start" - a test run is beginning for all browsers
   this.onRunStart = function (browsers) {
     suites = Object.create(null)
 
@@ -112,10 +113,12 @@ var JUnitReporter = function (baseReporterDecorator, config, logger, helper, for
     browsers.forEach(initializeXmlForBrowser)
   }
 
+  // "browser_start" - a test run is beginning in _this_ browser
   this.onBrowserStart = function (browser) {
     initializeXmlForBrowser(browser)
   }
 
+  // "browser_complete" - a test run has completed in _this_ browser
   this.onBrowserComplete = function (browser) {
     var suite = suites[browser.id]
     var result = browser.lastResult
@@ -134,8 +137,8 @@ var JUnitReporter = function (baseReporterDecorator, config, logger, helper, for
     writeXmlForBrowser(browser)
   }
 
+  // "run_complete" - a test run has completed on all browsers
   this.onRunComplete = function () {
-    suites = null
     allMessages.length = 0
   }
 

--- a/test/reporter.spec.js
+++ b/test/reporter.spec.js
@@ -104,4 +104,30 @@ describe('JUnit reporter', function () {
     // never pass a null value to XMLAttribute via xmlbuilder attr()
     expect(reporter.onBrowserComplete.bind(reporter, badBrowserResult)).not.to.throw(Error)
   })
+
+  it('should safely handle test re-runs triggered by watchers', function () {
+    var fakeBrowser = {
+      id: 'Android_4_1_2',
+      name: 'Android',
+      fullName: 'Android 4.1.2',
+      lastResult: {
+        error: false,
+        total: 1,
+        failed: 0,
+        netTime: 10 * 1000
+      }
+    }
+
+    reporter.onRunStart([ fakeBrowser ])
+    reporter.onBrowserStart(fakeBrowser)
+
+    // When a watcher triggers a second test run, onRunStart() for the second
+    // run gets triggered, followed by onRunComplete() from the first test run.
+    reporter.onRunStart([ fakeBrowser ])
+    reporter.onRunComplete()
+
+    reporter.onBrowserStart(fakeBrowser)
+    reporter.onBrowserComplete(fakeBrowser)
+    reporter.onRunComplete()
+  })
 })


### PR DESCRIPTION
When a watcher triggers Karma to re-run a test, onRunComplete() from
the first test run happens after onRunStart() from the second test run.
This results in `suites` incorrectly clobbered to null.

Nulling it out is unnecessary as long as onRunStart() initializes
`suites`.

Fixes #99.