### PR TITLE
Defend against run events firing in the wrong order.

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,9 @@ var JUnitReporter = function (baseReporterDecorator, config, logger, helper, for
 
   var initializeXmlForBrowser = function (browser) {
     var timestamp = (new Date()).toISOString().substr(0, 19)
+    if( suites == null ) {
+      suites = Object.create(null) // OnRunStart() didn't fire yet, but it's not too late..
+    }
     var suite = suites[browser.id] = builder.create('testsuite')
     suite.att('name', browser.name)
       .att('package', pkgName)
@@ -77,7 +80,10 @@ var JUnitReporter = function (baseReporterDecorator, config, logger, helper, for
     } else {
       newOutputFile = path.join(outputDir, 'TESTS.xml')
     }
-
+    
+    if( suites == null ) {
+      return // Initialisation hasn't run yet - bail out.
+    }
     var xmlToOutput = suites[browser.id]
     if (!xmlToOutput) {
       return // don't die if browser didn't start
@@ -120,6 +126,9 @@ var JUnitReporter = function (baseReporterDecorator, config, logger, helper, for
 
   // "browser_complete" - a test run has completed in _this_ browser
   this.onBrowserComplete = function (browser) {
+    if( suites == null ) {
+      return // initialisation hasn't run yet - bail out.
+    }
     var suite = suites[browser.id]
     var result = browser.lastResult
     if (!suite || !result) {
@@ -143,6 +152,10 @@ var JUnitReporter = function (baseReporterDecorator, config, logger, helper, for
   }
 
   this.specSuccess = this.specSkipped = this.specFailure = function (browser, result) {
+ 
+    if( suites == null ) {
+      return; // Initialisation hasn't run yet, so no suites object, so no results.
+    }
     var testsuite = suites[browser.id]
 
     if (!testsuite) {


### PR DESCRIPTION
See https://github.com/karma-runner/karma-junit-reporter/issues/61#issuecomment-264468229 as for why.

What this mainly does is expose the real problem: onRunStart() firing out-of-order with the rest.
Looks like there are some races somewhere, but I'm not convinced the problem lies within karma-junit-test itself.

New error output:
---
Running "karma:unit" (karma) task
[D] Task source: C:\DATA\git\ymonitor-frontend\node_modules\grunt-karma\tasks\grunt-karma.js
Verifying property karma.unit exists in config...OK
File: [no files]
Options: background=false, client={}
02 12 2016 16:17:47.082:INFO [karma]: Karma v0.13.22 server started at http://localhost:8084/
02 12 2016 16:17:47.091:INFO [launcher]: Starting browser PhantomJS
02 12 2016 16:17:48.802:INFO [PhantomJS 2.1.1 (Windows 7 0.0.0)]: Connected on socket NHQQtIYrup2fNrbRAAAA with id 58745719
Warning: Task "karma:unit" failed. Use --force to continue.
Error: Task "karma:unit" failed.
    at Task.<anonymous> (C:\DATA\git\ymonitor-frontend\node_modules\grunt\lib\util\task.js:205:15)
    at null._onTimeout (C:\DATA\git\ymonitor-frontend\node_modules\grunt\lib\util\task.js:241:33)
    at Timer.listOnTimeout (timers.js:92:15)

Aborted due to warnings.
---