### PR TITLE
Release memory held by a testsuite after we're done with it.

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ var JUnitReporter = function (baseReporterDecorator, config, logger, helper, for
   var classNameFormatter = reporterConfig.classNameFormatter
   var properties = reporterConfig.properties
 
-  var suites
+  var suites = []
   var pendingFileWritings = 0
   var fileWritingFinished = function () {}
   var allMessages = []
@@ -107,8 +107,6 @@ var JUnitReporter = function (baseReporterDecorator, config, logger, helper, for
 
   // "run_start" - a test run is beginning for all browsers
   this.onRunStart = function (browsers) {
-    suites = Object.create(null)
-
     // TODO(vojta): remove once we don't care about Karma 0.10
     browsers.forEach(initializeXmlForBrowser)
   }

--- a/index.js
+++ b/index.js
@@ -133,6 +133,9 @@ var JUnitReporter = function (baseReporterDecorator, config, logger, helper, for
     suite.ele('system-err')
 
     writeXmlForBrowser(browser)
+
+    // Release memory held by the test suite.
+    suites[browser.id] = null
   }
 
   // "run_complete" - a test run has completed on all browsers


### PR DESCRIPTION
When a test finishes and the result has been written out the reference to the testsuite in the suites object can be dropped.
Ideally we'd drop the reference from the array entirely but that involves recreating the array and *that* might race.
So instead we just make the testsuite object point to 'null'.