### PR TITLE
chore: change to use object

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ var JUnitReporter = function (baseReporterDecorator, config, logger, helper, for
   var classNameFormatter = reporterConfig.classNameFormatter
   var properties = reporterConfig.properties
 
-  var suites = []
+  var suites = {}
   var pendingFileWritings = 0
   var fileWritingFinished = function () {}
   var allMessages = []


### PR DESCRIPTION
- Change to use object as array is not the correct data structure due to browser ids being randomly generated numbers