### PR TITLE
Added allowSurrogateChars option.

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ var JUnitReporter = function (baseReporterDecorator, config, logger, helper, for
   var nameFormatter = reporterConfig.nameFormatter || defaultNameFormatter
   var classNameFormatter = reporterConfig.classNameFormatter
   var properties = reporterConfig.properties
+  var allowSurrogateChars = reporterConfig.allowSurrogateChars
 
   var suites = []
   var pendingFileWritings = 0
@@ -45,7 +46,12 @@ var JUnitReporter = function (baseReporterDecorator, config, logger, helper, for
 
   var initializeXmlForBrowser = function (browser) {
     var timestamp = (new Date()).toISOString().substr(0, 19)
-    var suite = suites[browser.id] = builder.create('testsuite')
+    var suite = suites[browser.id] = builder.create(
+      'testsuite',
+      null,
+      null,
+      { allowSurrogateChars: allowSurrogateChars }
+    )
     suite.att('name', browser.name)
       .att('package', pkgName)
       .att('timestamp', timestamp)


### PR DESCRIPTION
Fixes #116. Adds an `allowSurrogateChars` option that gets passed to the XMLBuilder.

In my case, a piece of code under test does a `console.log('\uD83D\uDE80 A message.');` The surrogate pair shows a rocketship icon in the console. When running the test under Karma using the karma-junit-reporter, the tests fail with an error because the XMLStringifier (inside the XMLBuilder) defaults to preventing surrogate characters from being used.