### PR TITLE
test: replace libxml-xsd in favor of libxmljs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: node_js
 node_js:
-  - 6
   - 8
+  - 10
 
 env:
   - CXX=g++-4.8
@@ -14,9 +14,11 @@ addons:
     packages:
       - g++-4.8
 
+services:
+  - xvfb
+
 # Make sure we have new NPM.
 before_install:
   - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
   - npm install -g npm
   - npm config set loglevel warn

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "karma": ">=0.9"
   },
   "engines": {
-    "node": ">= 6 < 9"
+    "node": ">= 8"
   },
   "license": "MIT",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "Derek Schaller <dschaller@lyft.com>",
     "Janek Lasocki-Biczysko <j.lasocki-biczysko@intrallect.com>",
     "John Haugeland <stonecypher@gmail.com>",
-    "Kira Cheung <killercentury@gmail.com>"
+    "Kira Cheung <killercentury@gmail.com>",
+    "Julen Garcia Leunda <hicom150@gmail.com>"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "grunt-eslint": "^18.1.0",
     "grunt-npm": "^0.0.2",
     "grunt-simple-mocha": "^0.4.1",
-    "libxml-xsd": "^0.5.2",
+    "libxmljs": "^0.19.5",
     "load-grunt-tasks": "^3.2.0",
     "mocha": "^3.2.0",
     "proxyquire": "^1.7.4",


### PR DESCRIPTION
`libxml-xsd` is obsolete and it doesn't support nodejs 10 in the other hand, `libxmljs` can be used to check xsd schemas.