### PR TITLE
fix: allow special characters and emoji in output

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "Vojta Jina <vojta.jina@gmail.com>",
   "dependencies": {
     "path-is-absolute": "^1.0.0",
-    "xmlbuilder": "8.2.2"
+    "xmlbuilder": "12.0.0"
   },
   "peerDependencies": {
     "karma": ">=0.9"


### PR DESCRIPTION
If an emoji is used anywhere in either suite description or inside an
error from a test (e.g. "Expected '👎' to be '👍'"), the reporter
chrashes with "Invalid character (�) in string: 😄 at index 0".

The root cause of this is xmlbuilder, that uses a version that is
3 years old at this time. The current version does not throw any
errors for this.

This PR will suggest updating to the latest version of xmlbuilder,
that includes a lot of bugfixes. As far as I could determine,
there were no breaking changes for this package.