### PR TITLE
Allow customization of testsuite name attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ module.exports = function(config) {
       useBrowserName: true, // add browser name to report and classes names
       nameFormatter: undefined, // function (browser, result) to customize the name attribute in xml testcase element
       classNameFormatter: undefined, // function (browser, result) to customize the classname attribute in xml testcase element
+      suiteNameFormatter: undefined, // function (browser) to customize the name attribute in xml testsuite element
       properties: {}, // key value pair of properties to add to the <properties> section of the report
       xmlVersion: null // use '1' if reporting to be per SonarQube 6.2 XML format
     }

--- a/index.js
+++ b/index.js
@@ -15,6 +15,10 @@ function defaultNameFormatter (browser, result) {
   return result.suite.join(' ') + ' ' + result.description
 }
 
+function defaultSuiteNameFormatter (browser) {
+  return browser.name
+}
+
 var JUnitReporter = function (baseReporterDecorator, config, logger, helper, formatError) {
   var log = logger.create('reporter.junit')
   var reporterConfig = config.junitReporter || {}
@@ -25,6 +29,7 @@ var JUnitReporter = function (baseReporterDecorator, config, logger, helper, for
   var useBrowserName = reporterConfig.useBrowserName
   var nameFormatter = reporterConfig.nameFormatter || defaultNameFormatter
   var classNameFormatter = reporterConfig.classNameFormatter
+  var suiteNameFormatter = reporterConfig.suiteNameFormatter || defaultSuiteNameFormatter
   var properties = reporterConfig.properties
   // The below two variables have to do with adding support for new SonarQube XML format
   var XMLconfigValue = reporterConfig.xmlVersion
@@ -75,11 +80,14 @@ var JUnitReporter = function (baseReporterDecorator, config, logger, helper, for
       exposee = suite.ele('file', {'path': 'fixedString'})
     } else {
       suite = suites[browser.id] = builder.create('testsuite')
-      suite.att('name', browser.name)
+      suite.att('name', suiteNameFormatter(browser))
       .att('package', pkgName)
       .att('timestamp', timestamp)
       .att('id', 0)
       .att('hostname', os.hostname())
+
+      suite.att('browser', browser.name)
+
       var propertiesElement = suite.ele('properties')
       propertiesElement.ele('property', {name: 'browser.fullName', value: browser.fullName})
 


### PR DESCRIPTION
I added the ability to customize the testsuite name attribute using a ```suiteNameFormatter``` function. The default behavior of this setting (if no function is passed) is to use the browser's name, which is what is currently being done.

The context for this is in VSTS, test results have to be in one of a very limited set of formats, including JUnit. They pull in the name attribute on the testsuite to identify the tests. Without being able to customize suite name, the results look like this:

![vsts](https://user-images.githubusercontent.com/10199133/63388768-26211800-c36f-11e9-84c3-18b362c46f6c.png)

