### PR TITLE
readme: Removing wrong language name in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ plugins: [
 ```
 
 Sonar property example:
-```js
+```
 sonar.projectName=js
 sonar.sources=site-main-php/src/main/webapp/public/js
 sonar.projectBaseDir=.


### PR DESCRIPTION
Fixes this wrong highlighting:

![image](https://user-images.githubusercontent.com/2410353/67478903-3dc19900-f65d-11e9-8d0c-40983462b137.png)
